### PR TITLE
Add `/canvas` for displaying courses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.edwardshturman</groupId>
     <artifactId>craftvas</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <packaging>jar</packaging>
 
     <name>Craftvas</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.edwardshturman</groupId>
     <artifactId>craftvas</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0</version>
     <packaging>jar</packaging>
 
     <name>Craftvas</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.edwardshturman</groupId>
     <artifactId>craftvas</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <packaging>jar</packaging>
 
     <name>Craftvas</name>

--- a/src/main/java/com/edwardshturman/craftvas/Canvas.java
+++ b/src/main/java/com/edwardshturman/craftvas/Canvas.java
@@ -4,14 +4,44 @@ import io.papermc.paper.command.brigadier.BasicCommand;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.bukkit.plugin.java.JavaPlugin;
 
 @NullMarked
 public class Canvas implements BasicCommand {
+    private final JavaPlugin plugin;
+
+    public Canvas(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @Override
     public void execute(CommandSourceStack source, String[] args) {
         if (args.length == 0) {
             source.getSender().sendRichMessage("<red>Need at least one argument");
+            return;
+        }
+
+        if (args[0].equalsIgnoreCase("url")) {
+            if (args[1].isEmpty()) {
+                source.getSender().sendRichMessage("<red>Need another argument to set the base URL");
+                return;
+            }
+
+            plugin.getConfig().set("canvas-base-url", args[1]);
+            plugin.saveConfig();
+            source.getSender().sendRichMessage("<gold>Set the base URL");
+            return;
+        }
+
+        if (args[0].equalsIgnoreCase("token")) {
+            if (args[1].isEmpty()) {
+                source.getSender().sendRichMessage("<red>Need another argument to set the token");
+                return;
+            }
+
+            plugin.getConfig().set("token", args[1]);
+            plugin.saveConfig();
+            source.getSender().sendRichMessage("<gold>Set the token");
             return;
         }
     }

--- a/src/main/java/com/edwardshturman/craftvas/Canvas.java
+++ b/src/main/java/com/edwardshturman/craftvas/Canvas.java
@@ -1,0 +1,23 @@
+package com.edwardshturman.craftvas;
+
+import io.papermc.paper.command.brigadier.BasicCommand;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+public class Canvas implements BasicCommand {
+
+    @Override
+    public void execute(CommandSourceStack source, String[] args) {
+        if (args.length == 0) {
+            source.getSender().sendRichMessage("<red>Need at least one argument");
+            return;
+        }
+    }
+
+    @Override
+    public @Nullable String permission() {
+        return "craftvas.canvas";
+    }
+}

--- a/src/main/java/com/edwardshturman/craftvas/Canvas.java
+++ b/src/main/java/com/edwardshturman/craftvas/Canvas.java
@@ -1,10 +1,20 @@
 package com.edwardshturman.craftvas;
 
+import edu.ksu.canvas.CanvasApiFactory;
+import edu.ksu.canvas.interfaces.CourseReader;
+import edu.ksu.canvas.model.Course;
+import edu.ksu.canvas.oauth.NonRefreshableOauthToken;
+import edu.ksu.canvas.oauth.OauthToken;
+import edu.ksu.canvas.requestOptions.ListCurrentUserCoursesOptions;
 import io.papermc.paper.command.brigadier.BasicCommand;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.IOException;
+import java.util.List;
 
 @NullMarked
 public class Canvas implements BasicCommand {
@@ -43,6 +53,28 @@ public class Canvas implements BasicCommand {
             plugin.saveConfig();
             source.getSender().sendRichMessage("<gold>Set the token");
             return;
+        }
+
+        if (args[0].equalsIgnoreCase("info")) {
+            FileConfiguration config = plugin.getConfig();
+            String canvasBaseUrl = config.getString("canvas-base-url");
+            String tokenString = config.getString("token");
+            plugin.getLogger().info("Using Canvas API URL: " + canvasBaseUrl);
+            OauthToken token = new NonRefreshableOauthToken(tokenString);
+            plugin.getLogger().info("Using token: " + token.getAccessToken());
+            CanvasApiFactory apiFactory = new CanvasApiFactory(canvasBaseUrl);
+
+            CourseReader courseReader = apiFactory.getReader(CourseReader.class, token);
+            try {
+                List<Course> courses = courseReader.listCurrentUserCourses(new ListCurrentUserCoursesOptions());
+                source.getSender().sendRichMessage("<gold>Craftvas sees courses:");
+                for (Course course : courses) {
+                    source.getSender().sendRichMessage("<gold>- " + course.getName());
+                }
+            } catch (IOException e) {
+                plugin.getLogger().severe("Failed to load account: " + e.getMessage());
+                source.getSender().sendRichMessage("<red>Failed to load account");
+            }
         }
     }
 

--- a/src/main/java/com/edwardshturman/craftvas/Craftvas.java
+++ b/src/main/java/com/edwardshturman/craftvas/Craftvas.java
@@ -12,14 +12,9 @@ public final class Craftvas extends JavaPlugin implements Listener {
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
         Bukkit.getPluginManager().registerEvents(this, this);
+        saveDefaultConfig();
         registerCommand("meow", new Meow());
-    }
-
-    @Override
-    public void onDisable() {
-        // Plugin shutdown logic
     }
 
     @EventHandler

--- a/src/main/java/com/edwardshturman/craftvas/Craftvas.java
+++ b/src/main/java/com/edwardshturman/craftvas/Craftvas.java
@@ -15,6 +15,7 @@ public final class Craftvas extends JavaPlugin implements Listener {
         Bukkit.getPluginManager().registerEvents(this, this);
         saveDefaultConfig();
         registerCommand("meow", new Meow());
+        registerCommand("canvas", new Canvas());
     }
 
     @EventHandler

--- a/src/main/java/com/edwardshturman/craftvas/Craftvas.java
+++ b/src/main/java/com/edwardshturman/craftvas/Craftvas.java
@@ -15,7 +15,7 @@ public final class Craftvas extends JavaPlugin implements Listener {
         Bukkit.getPluginManager().registerEvents(this, this);
         saveDefaultConfig();
         registerCommand("meow", new Meow());
-        registerCommand("canvas", new Canvas());
+        registerCommand("canvas", new Canvas(this));
     }
 
     @EventHandler

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,2 @@
+canvas-base-url: https://canvas.instructure.com
+token:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Craftvas
-version: '0.3.0'
+version: '0.4.0'
 main: com.edwardshturman.craftvas.Craftvas
 description: Integrate with the Canvas LMS
 author: Edward Shturman
@@ -19,5 +19,5 @@ commands:
     permission: craftvas.meow
   canvas:
     description: "A set of utility commands for interfacing with the Canvas API"
-    usage: "/canvas"
+    usage: "/canvas <url [url] | token [token]>"
     permission: craftvas.canvas

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Craftvas
-version: '0.2.0'
+version: '0.3.0'
 main: com.edwardshturman.craftvas.Craftvas
 description: Integrate with the Canvas LMS
 author: Edward Shturman
@@ -9,8 +9,15 @@ permissions:
   craftvas.meow:
     description: "Broadcast a meow"
     default: op
+  craftvas.canvas:
+    description: "Permission to interface with the Canvas API"
+    default: op
 commands:
   meow:
     description: "Broadcast a meow"
     usage: "/meow"
     permission: craftvas.meow
+  canvas:
+    description: "A set of utility commands for interfacing with the Canvas API"
+    usage: "/canvas"
+    permission: craftvas.canvas

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Craftvas
-version: '0.4.0'
+version: '0.5.0'
 main: com.edwardshturman.craftvas.Craftvas
 description: Integrate with the Canvas LMS
 author: Edward Shturman
@@ -19,5 +19,5 @@ commands:
     permission: craftvas.meow
   canvas:
     description: "A set of utility commands for interfacing with the Canvas API"
-    usage: "/canvas <url [url] | token [token]>"
+    usage: "/canvas <info | url [url] | token [token]>"
     permission: craftvas.canvas


### PR DESCRIPTION
This PR:

- Adds a default `config.yml` with placeholder `canvas-base-url` and `token` values
  - Note: currently relies on manually inputting a personal access token, OAuth to come soon™
- Adds `/canvas`
  - `/canvas token <token>` updates the `token` value in `config.yml`
  - `/canvas url <url>` updates the `canvas-base-url` value in config.yml`
  - `/canvas info` displays all enrolled courses for the user associated with the personal access token
